### PR TITLE
[bugfix] make unbound_version `--check` safe, update and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,6 @@
 
 Configures `unbound`.
 
-## chroot support
-
-When `unbound_config_chroot` is not empty, the role creates necessary files for
-unbound. Supported platform includes:
-
-* OpenBSD
-* FreeBSD
-
-The implementation of `unbound_config_chroot` is quite hackish and is subject
-to change.
-
-See `tests/serverspec/chroot.yml` for the details.
-
 # Requirements
 
 None
@@ -26,6 +13,7 @@ None
 | `unbound_user` | user of `unbound` | `{{ __unbound_user }}` |
 | `unbound_group` | group of `unbound` | `{{ __unbound_group }}` |
 | `unbound_service` | service name of `unbound` | `unbound` |
+| `unbound_package` | package name of `unbound` | `unbound` |
 | `unbound_conf_dir` | path to config directory | `{{ __unbound_conf_dir }}` |
 | `unbound_conf_file` | path to `unbound.conf(5)` | `{{ unbound_conf_dir }}/unbound.conf` |
 | `unbound_flags` | dict of variables and their values in startup scripts. this variable is combined with `unbound_flags_default` (see below). | `{}` |
@@ -111,7 +99,8 @@ value is empty string.
 
 # Dependencies
 
-None
+* [`trombik.x509-certificate`](https://github.com/trombik/ansible-role-x509-certificate)
+  if `unbound_include_role_x509_certificate` is set to true value.
 
 # Example Playbook
 
@@ -176,7 +165,7 @@ None
       {% if unbound_version | version_compare('1.5.2', '>=') %}
         control-use-cert: no
       {% endif %}
-      {% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('14.04', '<=')) or (ansible_distribution == 'CentOS' and ansible_distribution_version | version_compare('7.4.1708', '<=')) %}
+      {% if unbound_version | version_compare('1.5.3', '<=') %}
         control-interface: 127.0.0.1
       {% else %}
         control-interface: /var/run/unbound.sock

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 unbound_user: "{{ __unbound_user }}"
 unbound_group: "{{ __unbound_group }}"
 unbound_service: unbound
+unbound_package: unbound
 unbound_conf_dir: "{{ __unbound_conf_dir }}"
 unbound_conf_file: "{{ unbound_conf_dir }}/unbound.conf"
 unbound_flags: {}

--- a/tasks/fact-Debian.yml
+++ b/tasks/fact-Debian.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Get unbound version
+  shell: "apt show {{ unbound_package }} | grep 'Version:' | sed -e 's/^Version: //' | cut -d ':' -f2 | cut -d '-' -f1"
+  register: register_unbound_version
+  check_mode: no
+  changed_when: false
+  when:
+    - ansible_distribution == 'Ubuntu'

--- a/tasks/fact-FreeBSD.yml
+++ b/tasks/fact-FreeBSD.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Get unbound version
+  shell: "pkg search -S name -e -Q version {{ unbound_package }} | grep '^Version' | sed -E -e 's/Version[[:space:]]+:[[:space:]]+//' | cut -d'_' -f1"
+  register: register_unbound_version
+  check_mode: no
+  changed_when: false

--- a/tasks/fact-OpenBSD.yml
+++ b/tasks/fact-OpenBSD.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Get unbound version
+  shell: "unbound -h | grep -E '^Version[[:space:]]+[[:digit:].]+$' | cut -f 2 -d' '"
+  register: register_unbound_version
+  check_mode: no
+  changed_when: false

--- a/tasks/fact-RedHat.yml
+++ b/tasks/fact-RedHat.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Get unbound version
+  shell: "yum -q list all {{ unbound_package }} | awk '$1 ~ /{{ unbound_package }}/ { print $2 }' | cut -d':' -f2 | cut -d'-' -f1"
+  register: register_unbound_version
+  check_mode: no
+  changed_when: false

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -2,7 +2,7 @@
 
 - name: Install unbound
   apt:
-    name: unbound
+    name: "{{ unbound_package }}"
     state: present
 
 - name: Install ldnsutils

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,29 @@
 - set_fact:
     unbound_flags_merged: "{{ unbound_flags_default | combine(unbound_flags) }}"
 
+- name: Include fact-{{ ansible_os_family }}.yml
+  include_tasks: "fact-{{ ansible_os_family }}.yml"
+
+- name: Assert register_unbound_version is defined
+  assert:
+    that:
+      - register_unbound_version is defined
+    msg: |
+      [BUG] register_unbound_version must be defined by
+      fact-{{ ansible_os_family }}.yml, but register_unbound_version is not
+      defined. This means the role has a bug in it.
+
+- set_fact:
+    unbound_version: "{{ register_unbound_version.stdout }}"
+
+- name: Assert unbound_version is in the expected format
+  assert:
+    that:
+      - unbound_version | match('^\d+\.\d+\.\d+$')
+    msg: |
+      [BUG] unbound_version does not match expected version pattern.
+      This means the role has a bug in it.
+
 - name: Include install-{{ ansible_os_family }}.yml
   include_tasks: "install-{{ ansible_os_family }}.yml"
 
@@ -16,24 +39,6 @@
 
 - name: Include "configure-{{ ansible_os_family }}.yml"
   include_tasks: "configure-{{ ansible_os_family }}.yml"
-
-- name: Register unbound version
-  shell: "unbound -h | grep -E '^Version[[:space:]]+[[:digit:].]+$' | cut -f 2 -d' '"
-  register: register_unbound_version
-  changed_when: false
-  check_mode: no
-
-- set_fact:
-    # unbound_version is available for use from this point. note that this
-    # fact, unlike facts defined by "setup" action, cannot be used in playbooks,
-    # group_var, etc.
-    unbound_version: "{{ register_unbound_version.stdout }}"
-
-- assert:
-    that:
-      - unbound_version | match('\d+[\d.]+\d+')
-  when:
-    - not ansible_check_mode
 
 - name: Create unbound_script_dir
   file:

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -58,7 +58,7 @@
       {% if unbound_version | version_compare('1.5.2', '>=') %}
         control-use-cert: no
       {% endif %}
-      {% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('14.04', '<=')) or (ansible_distribution == 'CentOS' and ansible_distribution_version | version_compare('7.4.1708', '<=')) %}
+      {% if unbound_version | version_compare('1.5.3', '<=') %}
         control-interface: 127.0.0.1
       {% else %}
         control-interface: /var/run/unbound.sock


### PR DESCRIPTION
the previoius implementation does not work with `ansible-play --check`.
it worked only after unbound is installed, i.e. it did not when the play
with `--check` is run for the first time because the package has not yet
installed.

introduce `unbound_package` variable.

also, remove chroot support, which was removed in past release,
documentation from README.