### PR TITLE
bugfix: remove guard clause

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,30 +22,9 @@ provisioner:
   ansible_vault_password_file: <%= File.expand_path(ENV['ANSIBLE_VAULT_PASSWORD_FILE'] || '') %>
 
 platforms:
-  - name: freebsd-11.2-amd64
+  - name: freebsd-12.1-amd64
     driver:
-      box: trombik/ansible-freebsd-11.2-amd64
-      box_check_update: false
-    driver_config:
-      ssh:
-        shell: '/bin/sh'
-    provisioner:
-      extra_vars:
-        ansible_python_interpreter: '/usr/local/bin/python'
-  - name: freebsd-12.0-amd64
-    driver:
-      box: trombik/ansible-freebsd-12.0-amd64
-      box_check_update: false
-    driver_config:
-      ssh:
-        shell: '/bin/sh'
-    provisioner:
-      extra_vars:
-        ansible_python_interpreter: '/usr/local/bin/python'
-
-  - name: openbsd-6.5-amd64
-    driver:
-      box: trombik/ansible-openbsd-6.5-amd64
+      box: trombik/ansible-freebsd-12.1-amd64
       box_check_update: false
     driver_config:
       ssh:
@@ -100,4 +79,4 @@ suites:
       # this test is intended to be a test that ensures the role includes
       # `x509-certificate` when told so, which is specific to the role, not
       # platforms. thus, testing on a signle platform is sufficient.
-      - freebsd-12.0-amd64
+      - freebsd-12.1-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ before_install:
   # available in travis environment, this can be removed.
   # see details at:
   # https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html
-  - gem update --system
+  - yes | gem update --system --force
+  - gem install bundler
 
 install:
   # Install ansible

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ node ('virtualbox') {
     } finally {
       sh 'bundle exec kitchen destroy'
     }
+/* if you have integration tests, uncomment the stage below
     stage 'integration'
     try {
       // use native rake instead of bundle exec rake
@@ -49,6 +50,7 @@ node ('virtualbox') {
     } finally {
       sh 'rake clean'
     }
+*/
     stage 'Notify'
     notifyBuild(currentBuild.result)
     step([$class: 'GitHubCommitNotifier', resultOnFailure: 'FAILURE'])

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ warning. See also [issue 4131](https://github.com/ansible/ansible/issues/41313).
 # Example Playbook
 
 ```yaml
----
 - hosts: localhost
   roles:
     - ansible-role-unbound
   vars:
+    unbound_force_flush_handlers: yes
     os_unbound_flags:
       FreeBSD: |
         unbound_flags="-v"
@@ -156,14 +156,8 @@ warning. See also [issue 4131](https://github.com/ansible/ansible/issues/41313).
         stub-addr: "8.8.8.8"
       remote-control:
         control-enable: yes
-      {% if unbound_version is version_compare('1.5.2', '>=') %}
         control-use-cert: no
-      {% endif %}
-      {% if unbound_version is version_compare('1.5.3', '<=') %}
-        control-interface: 127.0.0.1
-      {% else %}
         control-interface: /var/run/unbound.sock
-      {% endif %}
         server-key-file: {{ unbound_conf_dir }}/unbound_server.key
         server-cert-file: {{ unbound_conf_dir }}/unbound_server.pem
         control-key-file: {{ unbound_conf_dir }}/unbound_control.key

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,12 +9,10 @@ galaxy_info:
   platforms:
     - name: FreeBSD
       versions:
-        - 11.2
-        - 12.0
+        - 12.1
     - name: OpenBSD
       versions:
         - 6.6
-        - 6.5
     - name: Ubuntu
       versions:
         - trusty

--- a/tasks/fact-Debian.yml
+++ b/tasks/fact-Debian.yml
@@ -5,5 +5,3 @@
   register: register_unbound_version
   check_mode: no
   changed_when: false
-  when:
-    - ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
the task file is included only when ansible_os_family is "Debian", and
there is no reason to exclude other ansible_distribution.

fixes #26 